### PR TITLE
Don't load non-existent style

### DIFF
--- a/lib/Listener/FilesLoadAdditionalScriptsListener.php
+++ b/lib/Listener/FilesLoadAdditionalScriptsListener.php
@@ -34,5 +34,8 @@ class FilesLoadAdditionalScriptsListener implements IEventListener
         } else {
             Util::addScript(Application::APP_ID, 'epubviewer-main');
         }
+
+        // We currently don't have a custom stylesheet, but you can uncomment this line the day we need it
+        // Util::addStyle(Application::APP_ID, 'epubviewer-main');
     }
 }

--- a/lib/Listener/FilesLoadAdditionalScriptsListener.php
+++ b/lib/Listener/FilesLoadAdditionalScriptsListener.php
@@ -34,7 +34,5 @@ class FilesLoadAdditionalScriptsListener implements IEventListener
         } else {
             Util::addScript(Application::APP_ID, 'epubviewer-main');
         }
-
-        Util::addStyle(Application::APP_ID, 'epubviewer-main');
     }
 }


### PR DESCRIPTION
Fix:

> Refused to apply style from 'https://nc.example.com/apps/epubviewer/css/epubviewer-main.css?v=ca9f0d77-36' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.