### PR TITLE
Feature: EPub cover previews using ext. dependency mikespub/php-epub-meta

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,6 @@
     "sabre/dav": "^4.7.0",
     "sabre/xml": "^2.2.11",
     "symfony/event-dispatcher": "^5.4.45",
-	"mikespub/php-epub-meta": "^1.5.3"
+    "mikespub/php-epub-meta": "^1.5.3"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
     "ext-json": "*",
     "sabre/dav": "^4.7.0",
     "sabre/xml": "^2.2.11",
-    "symfony/event-dispatcher": "^5.4.45"
+    "symfony/event-dispatcher": "^5.4.45",
+	"mikespub/php-epub-meta": "^1.5.3"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,78 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "02b7a098f52dd90d6096b1d53f82582c",
+  "content-hash": "78104b3d77ada29aba6596beeff5d879",
   "packages": [
+    {
+      "name": "mikespub/php-epub-meta",
+      "version": "1.5.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/mikespub-org/php-epub-meta.git",
+        "reference": "37170e25d86f8f499f1a60f079ded406b54cbe15"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/mikespub-org/php-epub-meta/zipball/37170e25d86f8f499f1a60f079ded406b54cbe15",
+        "reference": "37170e25d86f8f499f1a60f079ded406b54cbe15",
+        "shasum": ""
+      },
+      "require": {
+        "ext-dom": "*",
+        "ext-xml": "*",
+        "ext-zip": "*",
+        "php": ">=7.4"
+      },
+      "require-dev": {
+        "phpunit/phpunit": "9.*"
+      },
+      "suggest": {
+        "mikespub/epub-loader": "epub-loader is a utility resource for ebooks",
+        "mikespub/seblucas-cops": "COPS - Calibre OPDS (and HTML) PHP Server"
+      },
+      "type": "library",
+      "autoload": {
+        "classmap": [
+          "src/",
+          "resources/tbszip/src/"
+        ]
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Andreas Gohr",
+          "email": "andi@splitbrain.org",
+          "homepage": "https://www.splitbrain.org/",
+          "role": "Developer"
+        },
+        {
+          "name": "Sébastien Lucas",
+          "email": "sebastien@slucas.fr",
+          "homepage": "http://www.slucas.fr/",
+          "role": "Developer"
+        },
+        {
+          "name": "mikespub",
+          "homepage": "https://github.com/mikespub-org/php-epub-meta",
+          "role": "Developer"
+        }
+      ],
+      "description": "Reading and writing metadata included in the EPub ebook format",
+      "homepage": "https://github.com/mikespub-org/php-epub-meta",
+      "keywords": [
+        "ebook",
+        "epub",
+        "metadata"
+      ],
+      "support": {
+        "issues": "https://github.com/mikespub-org/php-epub-meta/issues",
+        "source": "https://github.com/mikespub-org/php-epub-meta/tree/1.5.3"
+      },
+      "time": "2023-09-10T15:05:48+00:00"
+    },
     {
       "name": "psr/event-dispatcher",
       "version": "1.0.0",
@@ -330,16 +400,16 @@
     },
     {
       "name": "sabre/vobject",
-      "version": "4.5.6",
+      "version": "4.5.7",
       "source": {
         "type": "git",
         "url": "https://github.com/sabre-io/vobject.git",
-        "reference": "900266bb3bd448a9f7f41f82344ad0aba237cb27"
+        "reference": "ff22611a53782e90c97be0d0bc4a5f98a5c0a12c"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sabre-io/vobject/zipball/900266bb3bd448a9f7f41f82344ad0aba237cb27",
-        "reference": "900266bb3bd448a9f7f41f82344ad0aba237cb27",
+        "url": "https://api.github.com/repos/sabre-io/vobject/zipball/ff22611a53782e90c97be0d0bc4a5f98a5c0a12c",
+        "reference": "ff22611a53782e90c97be0d0bc4a5f98a5c0a12c",
         "shasum": ""
       },
       "require": {
@@ -349,7 +419,7 @@
       },
       "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.17.1",
-        "phpstan/phpstan": "^0.12 || ^1.11",
+        "phpstan/phpstan": "^0.12 || ^1.12 || ^2.0",
         "phpunit/php-invoker": "^2.0 || ^3.1",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6"
       },
@@ -430,7 +500,7 @@
         "issues": "https://github.com/sabre-io/vobject/issues",
         "source": "https://github.com/fruux/sabre-vobject"
       },
-      "time": "2024-10-14T11:53:54+00:00"
+      "time": "2025-04-17T09:22:48+00:00"
     },
     {
       "name": "sabre/xml",
@@ -503,16 +573,16 @@
     },
     {
       "name": "symfony/deprecation-contracts",
-      "version": "v3.5.1",
+      "version": "v3.6.0",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/deprecation-contracts.git",
-        "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+        "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-        "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+        "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+        "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
         "shasum": ""
       },
       "require": {
@@ -525,7 +595,7 @@
           "name": "symfony/contracts"
         },
         "branch-alias": {
-          "dev-main": "3.5-dev"
+          "dev-main": "3.6-dev"
         }
       },
       "autoload": {
@@ -550,7 +620,7 @@
       "description": "A generic function and convention to trigger deprecation notices",
       "homepage": "https://symfony.com",
       "support": {
-        "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+        "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
       },
       "funding": [
         {
@@ -566,7 +636,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2024-09-25T14:20:29+00:00"
+      "time": "2024-09-25T14:21:43+00:00"
     },
     {
       "name": "symfony/event-dispatcher",
@@ -655,16 +725,16 @@
     },
     {
       "name": "symfony/event-dispatcher-contracts",
-      "version": "v3.5.1",
+      "version": "v3.6.0",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-        "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+        "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
-        "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+        "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+        "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
         "shasum": ""
       },
       "require": {
@@ -678,7 +748,7 @@
           "name": "symfony/contracts"
         },
         "branch-alias": {
-          "dev-main": "3.5-dev"
+          "dev-main": "3.6-dev"
         }
       },
       "autoload": {
@@ -711,7 +781,7 @@
         "standards"
       ],
       "support": {
-        "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+        "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
       },
       "funding": [
         {
@@ -727,20 +797,20 @@
           "type": "tidelift"
         }
       ],
-      "time": "2024-09-25T14:20:29+00:00"
+      "time": "2024-09-25T14:21:43+00:00"
     },
     {
       "name": "symfony/polyfill-php80",
-      "version": "v1.31.0",
+      "version": "v1.32.0",
       "source": {
         "type": "git",
         "url": "https://github.com/symfony/polyfill-php80.git",
-        "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+        "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-        "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+        "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+        "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
         "shasum": ""
       },
       "require": {
@@ -791,7 +861,7 @@
         "shim"
       ],
       "support": {
-        "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+        "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
       },
       "funding": [
         {
@@ -807,7 +877,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2024-09-09T11:45:10+00:00"
+      "time": "2025-01-02T08:10:11+00:00"
     }
   ],
   "packages-dev": [
@@ -883,16 +953,16 @@
     },
     {
       "name": "kubawerlos/php-cs-fixer-custom-fixers",
-      "version": "v3.23.0",
+      "version": "v3.27.0",
       "source": {
         "type": "git",
         "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
-        "reference": "b3210c6e546bdfc95664297a8971ae3b6b1f4a5a"
+        "reference": "d860473d16b906c7945206177edc7d112357a706"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/b3210c6e546bdfc95664297a8971ae3b6b1f4a5a",
-        "reference": "b3210c6e546bdfc95664297a8971ae3b6b1f4a5a",
+        "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/d860473d16b906c7945206177edc7d112357a706",
+        "reference": "d860473d16b906c7945206177edc7d112357a706",
         "shasum": ""
       },
       "require": {
@@ -902,7 +972,7 @@
         "php": "^7.4 || ^8.0"
       },
       "require-dev": {
-        "phpunit/phpunit": "^9.6.4 || ^10.5.29"
+        "phpunit/phpunit": "^9.6.22 || 10.5.45 || ^11.5.7"
       },
       "type": "library",
       "autoload": {
@@ -923,22 +993,28 @@
       "description": "A set of custom fixers for PHP CS Fixer",
       "support": {
         "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
-        "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.23.0"
+        "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.27.0"
       },
-      "time": "2025-02-15T09:15:56+00:00"
+      "funding": [
+        {
+          "url": "https://github.com/kubawerlos",
+          "type": "github"
+        }
+      ],
+      "time": "2025-06-10T20:53:07+00:00"
     },
     {
       "name": "myclabs/deep-copy",
-      "version": "1.13.0",
+      "version": "1.13.1",
       "source": {
         "type": "git",
         "url": "https://github.com/myclabs/DeepCopy.git",
-        "reference": "024473a478be9df5fdaca2c793f2232fe788e414"
+        "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/024473a478be9df5fdaca2c793f2232fe788e414",
-        "reference": "024473a478be9df5fdaca2c793f2232fe788e414",
+        "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
+        "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
         "shasum": ""
       },
       "require": {
@@ -977,7 +1053,7 @@
       ],
       "support": {
         "issues": "https://github.com/myclabs/DeepCopy/issues",
-        "source": "https://github.com/myclabs/DeepCopy/tree/1.13.0"
+        "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
       },
       "funding": [
         {
@@ -985,7 +1061,7 @@
           "type": "tidelift"
         }
       ],
-      "time": "2025-02-12T12:17:51+00:00"
+      "time": "2025-04-29T12:36:36+00:00"
     },
     {
       "name": "nextcloud/coding-standard",
@@ -1031,16 +1107,16 @@
     },
     {
       "name": "nikic/php-parser",
-      "version": "v5.4.0",
+      "version": "v5.5.0",
       "source": {
         "type": "git",
         "url": "https://github.com/nikic/PHP-Parser.git",
-        "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+        "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-        "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+        "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+        "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
         "shasum": ""
       },
       "require": {
@@ -1083,9 +1159,9 @@
       ],
       "support": {
         "issues": "https://github.com/nikic/PHP-Parser/issues",
-        "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+        "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
       },
-      "time": "2024-12-30T11:07:19+00:00"
+      "time": "2025-05-31T08:24:38+00:00"
     },
     {
       "name": "phar-io/manifest",
@@ -1207,16 +1283,16 @@
     },
     {
       "name": "php-cs-fixer/shim",
-      "version": "v3.70.0",
+      "version": "v3.75.0",
       "source": {
         "type": "git",
         "url": "https://github.com/PHP-CS-Fixer/shim.git",
-        "reference": "9302388f32d5181cd7238717860391396c592f36"
+        "reference": "eea219a577085bd13ff0cb644a422c20798316c7"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/9302388f32d5181cd7238717860391396c592f36",
-        "reference": "9302388f32d5181cd7238717860391396c592f36",
+        "url": "https://api.github.com/repos/PHP-CS-Fixer/shim/zipball/eea219a577085bd13ff0cb644a422c20798316c7",
+        "reference": "eea219a577085bd13ff0cb644a422c20798316c7",
         "shasum": ""
       },
       "require": {
@@ -1253,9 +1329,9 @@
       "description": "A tool to automatically fix PHP code style",
       "support": {
         "issues": "https://github.com/PHP-CS-Fixer/shim/issues",
-        "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.70.0"
+        "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.75.0"
       },
-      "time": "2025-02-22T23:31:12+00:00"
+      "time": "2025-03-31T18:45:02+00:00"
     },
     {
       "name": "phpunit/php-code-coverage",
@@ -1578,16 +1654,16 @@
     },
     {
       "name": "phpunit/phpunit",
-      "version": "9.6.22",
+      "version": "9.6.23",
       "source": {
         "type": "git",
         "url": "https://github.com/sebastianbergmann/phpunit.git",
-        "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c"
+        "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95"
       },
       "dist": {
         "type": "zip",
-        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
-        "reference": "f80235cb4d3caa59ae09be3adf1ded27521d1a9c",
+        "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
+        "reference": "43d2cb18d0675c38bd44982a5d1d88f6d53d8d95",
         "shasum": ""
       },
       "require": {
@@ -1598,7 +1674,7 @@
         "ext-mbstring": "*",
         "ext-xml": "*",
         "ext-xmlwriter": "*",
-        "myclabs/deep-copy": "^1.12.1",
+        "myclabs/deep-copy": "^1.13.1",
         "phar-io/manifest": "^2.0.4",
         "phar-io/version": "^3.2.1",
         "php": ">=7.3",
@@ -1661,7 +1737,7 @@
       "support": {
         "issues": "https://github.com/sebastianbergmann/phpunit/issues",
         "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.22"
+        "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.23"
       },
       "funding": [
         {
@@ -1673,11 +1749,19 @@
           "type": "github"
         },
         {
+          "url": "https://liberapay.com/sebastianbergmann",
+          "type": "liberapay"
+        },
+        {
+          "url": "https://thanks.dev/u/gh/sebastianbergmann",
+          "type": "thanks_dev"
+        },
+        {
           "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
           "type": "tidelift"
         }
       ],
-      "time": "2024-12-05T13:48:26+00:00"
+      "time": "2025-05-02T06:40:34+00:00"
     },
     {
       "name": "psalm/phar",

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,8 @@ class Application extends App implements IBootstrap {
 			);
 		});
 
+		$this->registerPreviewProviders($context);
+
 		// "Emitted before the rendering step of each TemplateResponse. The event holds a flag that specifies if a user is logged in."
 		// See: https://docs.nextcloud.com/server/latest/developer_manual/basics/events.html#oca-settings-events-beforetemplaterenderedevent
 		$context->registerEventListener(\OCP\AppFramework\Http\Events\BeforeTemplateRenderedEvent::class, BeforeTemplateRenderedListener::class);
@@ -63,6 +65,10 @@ class Application extends App implements IBootstrap {
 
 		$context->registerEventListener(\OCP\Files\Events\Node\NodeDeletedEvent::class, FileNodeDeletedListener::class);
 		$context->registerEventListener(\OCP\User\Events\UserDeletedEvent::class, UserDeletedListener::class);
+	}
+
+	private function registerPreviewProviders(IRegistrationContext $context): void {
+		$context->registerPreviewProvider(\OCA\Epubviewer\Preview\EPubPreview::class, '/^application\/epub\+zip$/');
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -32,15 +32,11 @@ use SebLucas\EPubMeta\EPub;
  */
 class EPubPreview extends ProviderV2 {
 
-	/** @var LoggerInterface dependency-injected logger */
-	private LoggerInterface $logger;
-
 	/**
 	 * @param LoggerInterface $logger dependency-injected logger
 	 */
-	public function __construct(LoggerInterface $logger) {
+	public function __construct(private LoggerInterface $logger) {
 		parent::__construct();
-		$this->logger = $logger;
 	}
 
 	/**

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -36,7 +36,7 @@ class EPubPreview implements IProviderV2 {
 	 * {@inheritDoc}
 	 */
 	public function getMimeType(): string {
-		return '/application\/epub\+zip/';
+		return '/^application\/epub\+zip$/';
 	}
 
 	/**
@@ -51,7 +51,7 @@ class EPubPreview implements IProviderV2 {
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
 		try {
-			$epub = new EPub($file->getPath());
+			$epub = new EPub($file->getStorage()->getLocalFile($file->getInternalPath()));
 			$coverInfo = $epub->getCoverInfo();
 			if (!$coverInfo["found"]) {
 				return null; // Successfully parsed, but no cover image.

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -82,7 +82,7 @@ class EPubPreview extends ProviderV2 {
 			// Found a cover, so attempt to convert it to an OC_Image.
 			$image->loadFromData($coverInfo['data']);
 			if (!$image->valid()) {
-				$this->logger->warning('EPUB file {file} contains cover \'{coverPath}\' (MIME: \'{coverMime}\') but it could not be loaded a valid image, so no thumbnail is generated.', [
+				$this->logger->warning('EPUB file {file} contains cover \'{coverPath}\' (MIME: \'{coverMime}\') but it could not be loaded as a valid image, so no thumbnail is generated.', [
 					'file' => $internalPath,
 					'coverPath' => $coverInfo['found'],
 					'coverMime' => $coverInfo['mime']

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *
+ * @author Sebastien Marinier <seb@smarinier.net>
+ *
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program. If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Epubviewer\Preview;
+
+use OCP\Files\File;
+use OCP\Files\FileInfo;
+use OCP\IImage;
+use OCP\Preview\IProviderV2;
+use SebLucas\EPubMeta\EPub;
+
+/**
+ * Preview generator for .epub e-book files.
+ */
+class EPubPreview implements IProviderV2 {
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getMimeType(): string {
+		return '/application\/epub\+zip/';
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isAvailable(FileInfo $file): bool {
+		return $file->getSize() > 0;
+	}
+
+	/**
+	 * @inheritDoc
+	 */
+	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
+		try {
+			$epub = new EPub($file->getPath());
+			$coverInfo = $epub->getCoverInfo();
+			if (!$coverInfo["found"]) {
+				return null; // Successfully parsed, but no cover image.
+			}
+		} catch (\Exception $e) {
+			return null; // Parse error, so treat as no cover image.
+		}
+
+		// Found a cover, so attempt to convert it to an OC_Image.
+		$image = new \OC_Image();
+		$image->loadFromData($coverInfo["data"]);
+		if (!$image->valid()) {
+			return null; // Invalid image, so don't provide a cover image.
+		}
+
+		// Resize the valid cover image, if necessary.
+		if ($image->width() > $maxX || $image->height() > $maxY) {
+			$image->resize(min($maxX, $maxY));
+		}
+		return $image;
+	}
+}

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -24,6 +24,7 @@ namespace OCA\Epubviewer\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
 use OCP\IImage;
+use OCP\Image;
 use OCP\Preview\IProviderV2;
 use SebLucas\EPubMeta\EPub;
 
@@ -61,7 +62,7 @@ class EPubPreview implements IProviderV2 {
 		}
 
 		// Found a cover, so attempt to convert it to an OC_Image.
-		$image = new \OC_Image();
+		$image = new Image();
 		$image->loadFromData($coverInfo["data"]);
 		if (!$image->valid()) {
 			return null; // Invalid image, so don't provide a cover image.

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -52,13 +52,6 @@ class EPubPreview extends ProviderV2 {
 	}
 
 	/**
-	 * {@inheritDoc}
-	 */
-	public function isAvailable(FileInfo $file): bool {
-		return $file->getSize() > 0;
-	}
-
-	/**
 	 * @inheritDoc
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -26,12 +26,23 @@ use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\Image;
 use OCP\Preview\IProviderV2;
+use Psr\Log\LoggerInterface;
 use SebLucas\EPubMeta\EPub;
 
 /**
  * Preview generator for .epub e-book files.
  */
 class EPubPreview implements IProviderV2 {
+
+	/** @var LoggerInterface dependency-injected logger */
+	private LoggerInterface $logger;
+
+	/**
+	 * @param LoggerInterface $logger dependency-injected logger
+	 */
+	public function __construct(LoggerInterface $logger) {
+		$this->logger = $logger;
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -51,27 +62,46 @@ class EPubPreview implements IProviderV2 {
 	 * @inheritDoc
 	 */
 	public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage {
+		$internalPath = $file->getInternalPath();
 		try {
-			$epub = new EPub($file->getStorage()->getLocalFile($file->getInternalPath()));
+			$fileStorage = $file->getStorage(); // may throw if storage is unavailable, caught below.
+
+			$localFile = $fileStorage->getLocalFile($internalPath);
+			if ($localFile === false) {
+				$this->logger->warning('Could not generate EPUB file thumbnail for {file} because the local file is unavailable.', ['file' => $internalPath]);
+				return null;
+			}
+
+			$epub = new EPub($localFile);
 			$coverInfo = $epub->getCoverInfo();
-			if (!$coverInfo["found"]) {
-				return null; // Successfully parsed, but no cover image.
+			if (!$coverInfo['found']) {
+				$this->logger->debug('EPUB file {file} parsed successfully, but no cover image was found to generate a thumbnail.', ['file' => $internalPath]);
+				return null;
 			}
 		} catch (\Exception $e) {
-			return null; // Parse error, so treat as no cover image.
+			$this->logger->warning('Failed to generate thumbnail for EPUB file {file}, error: {error}.', [
+				'file' => $internalPath,
+				'error' => $e->getMessage(),
+				'exception' => $e
+			]);
+			return null;
 		}
 
 		// Found a cover, so attempt to convert it to an OC_Image.
 		$image = new Image();
-		$image->loadFromData($coverInfo["data"]);
+		$image->loadFromData($coverInfo['data']);
 		if (!$image->valid()) {
-			return null; // Invalid image, so don't provide a cover image.
+			$this->logger->warning('EPUB file {file} contains cover \'{cover}\' (MIME: \'{mime}\') but it could not be loaded a valid image, so no thumbnail is generated.', [
+				'file' => $internalPath,
+				'cover' => $coverInfo['found'],
+				'mime' => $coverInfo['mime']
+			]);
+			return null;
 		}
 
-		// Resize the valid cover image, if necessary.
-		if ($image->width() > $maxX || $image->height() > $maxY) {
-			$image->resize(min($maxX, $maxY));
-		}
+		// Scale image to fit to the maximum dimensions if necessary.
+		$image->scaleDownToFit($maxX, $maxY);
+
 		return $image;
 	}
 }

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -21,9 +21,7 @@
 
 namespace OCA\Epubviewer\Preview;
 
-use OCA\Preview\ProviderV2;
 use OCP\Files\File;
-use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\Image;
 use Psr\Log\LoggerInterface;

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -23,7 +23,6 @@ namespace OCA\Epubviewer\Preview;
 
 use OC\Preview\ProviderV2;
 use OCP\Files\File;
-use OCP\Files\FileInfo;
 use OCP\IImage;
 use OCP\Image;
 use Psr\Log\LoggerInterface;
@@ -64,6 +63,11 @@ class EPubPreview extends ProviderV2 {
 			}
 
 			$epub = new EPub($localFile);
+
+			// CoverInfo is an associative array with the following keys:
+			// - mime: the mime type of the cover image in the data key, or image/gif if none found
+			// - data: the data of the cover image, or a transparent GIF pixel if none found
+			// - found: a string containing the cover archive file path, or false if none found
 			$coverInfo = $epub->getCoverInfo();
 			if (!$coverInfo['found']) {
 				$this->logger->debug('EPUB file {file} parsed successfully, but no cover image was found to generate a thumbnail.', ['file' => $internalPath]);

--- a/lib/Preview/EPubPreview.php
+++ b/lib/Preview/EPubPreview.php
@@ -39,6 +39,7 @@ class EPubPreview extends ProviderV2 {
 	 * @param LoggerInterface $logger dependency-injected logger
 	 */
 	public function __construct(LoggerInterface $logger) {
+		parent::__construct();
 		$this->logger = $logger;
 	}
 

--- a/lib/Preview/ProviderV2.php
+++ b/lib/Preview/ProviderV2.php
@@ -1,0 +1,114 @@
+<?php
+
+// Maintainer's note:
+// ---
+// This file is a copy-paste from the nextcloud/server repository, moved to the OCA namespace, because we need it, but it's in the private \OC\Preview namespace.
+// https://github.com/nextcloud/server/blob/64208b6d2273269cd51bb6e4a7aa939a144bc93c/lib/private/Preview/ProviderV2.php
+// ---
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\Preview;
+
+use OCP\Files\File;
+use OCP\Files\FileInfo;
+use OCP\IImage;
+use OCP\ITempManager;
+use OCP\Preview\IProviderV2;
+use OCP\Server;
+use Psr\Log\LoggerInterface;
+
+abstract class ProviderV2 implements IProviderV2 {
+	protected array $tmpFiles = [];
+
+	public function __construct(
+		protected array $options = [],
+	) {
+	}
+
+	/**
+	 * @return string Regex with the mimetypes that are supported by this provider
+	 */
+	abstract public function getMimeType(): string ;
+
+	/**
+	 * Check if a preview can be generated for $path
+	 *
+	 * @param FileInfo $file
+	 * @return bool
+	 */
+	public function isAvailable(FileInfo $file): bool {
+		return true;
+	}
+
+	/**
+	 * get thumbnail for file at path $path
+	 *
+	 * @param File $file
+	 * @param int $maxX The maximum X size of the thumbnail. It can be smaller depending on the shape of the image
+	 * @param int $maxY The maximum Y size of the thumbnail. It can be smaller depending on the shape of the image
+	 * @return null|\OCP\IImage null if no preview was generated
+	 * @since 17.0.0
+	 */
+	abstract public function getThumbnail(File $file, int $maxX, int $maxY): ?IImage;
+
+	protected function useTempFile(File $file): bool {
+		return $file->isEncrypted() || !$file->getStorage()->isLocal();
+	}
+
+	/**
+	 * Get a path to either the local file or temporary file
+	 *
+	 * @param File $file
+	 * @param ?int $maxSize maximum size for temporary files
+	 */
+	protected function getLocalFile(File $file, ?int $maxSize = null): string|false {
+		if ($this->useTempFile($file)) {
+			$absPath = Server::get(ITempManager::class)->getTemporaryFile();
+
+			if ($absPath === false) {
+				Server::get(LoggerInterface::class)->error(
+					'Failed to get local file to generate thumbnail for: ' . $file->getPath(),
+					['app' => 'core']
+				);
+				return false;
+			}
+
+			$content = $file->fopen('r');
+			if ($content === false) {
+				return false;
+			}
+
+			if ($maxSize) {
+				$content = stream_get_contents($content, $maxSize);
+			}
+
+			file_put_contents($absPath, $content);
+			$this->tmpFiles[] = $absPath;
+			return $absPath;
+		} else {
+			$path = $file->getStorage()->getLocalFile($file->getInternalPath());
+			if (is_string($path)) {
+				return $path;
+			} else {
+				return false;
+			}
+		}
+	}
+
+	/**
+	 * Clean any generated temporary files
+	 */
+	protected function cleanTmpFiles(): void {
+		foreach ($this->tmpFiles as $tmpFile) {
+			unlink($tmpFile);
+		}
+
+		$this->tmpFiles = [];
+	}
+}

--- a/lib/Preview/ProviderV2.php
+++ b/lib/Preview/ProviderV2.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-namespace OCA\Preview;
+namespace OCA\Epubviewer\Preview;
 
 use OCP\Files\File;
 use OCP\Files\FileInfo;


### PR DESCRIPTION
This change is based on the earlier attempt to get this feature merged by @smarinier in now-closed PR #21 (though written from scratch and branched from current `master`).

I believe this should work, but I'm having a very painful experience trying to test this on my Windows system. I'm creating this PR to see what hurdles we still need to overcome, and in the meantime (read: not today) I will work on a linux setup to hopefully validate the functionality locally.

If you can help out with testing, please do.

NB: I can't use a modern version of the introduced dependency (^3.0.0) since it required PHP 8.2+ whereas the project itself is committed to 8.0+, so I had to use an older version for now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for generating thumbnail previews of EPUB (.epub) files, displaying their cover images when available.
- **Chores**
  - Updated dependencies to include EPUB metadata extraction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->