### PR TITLE
Add lastModified field on Preference API to handle possible sync on third party apps

### DIFF
--- a/lib/Db/Preference.php
+++ b/lib/Db/Preference.php
@@ -63,6 +63,7 @@ class Preference extends Entity implements JsonSerializable {
 		return [
 			'name' => $this->getName(),
 			'value' => self::conditional_json_decode($this->getValue()),
+			'lastModified' => $this->getLastModified(),
 		];
 	}
 }


### PR DESCRIPTION
Hello

I'm currently developing a mobile app that connect to Nextcloud to be able to read your epubs (and in the future all formats that epubviewer support) OFFLINE with sync support with epubviewer.

It utilize the bookmarks and preferences API of epubviewer to sync the user bookmarks and read status.

Although I can achieve full support on sync on the bookmarks part, I can't do it efficiently on the preferences side because it does not export the lastModified field when you call the API.

Thus this PR is here to help me with that.

You can follow the development of my app here : https://git.crystalyx.net/Xefir/nextcloud_books
It's in really early phase and will not be ready until several month but I confident enough to have something working in the end.

Thank you.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The output of user preferences now includes the last modified date, providing more detailed information when viewing preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->