### PR TITLE
Fix Nextcloud 34 compatibility (OC:: removal + CSP nonce update + leg…

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -54,7 +54,7 @@ See [README] for more exhaustive information on features and potential misfeatur
     </screenshot>
     <dependencies>
         <php min-version="8.1" max-version="8.5" />
-        <nextcloud min-version="32" max-version="33" />
+        <nextcloud min-version="32" max-version="34" />
     </dependencies>
     <namespace>Epubviewer</namespace>
     <settings>

--- a/templates/cbreader.php
+++ b/templates/cbreader.php
@@ -1,4 +1,6 @@
 <?php
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+use OCP\Server;
 /** @var array $_ */
 /** @var OCP\IURLGenerator $urlGenerator */
 $urlGenerator = $_['urlGenerator'];
@@ -13,15 +15,26 @@ $preferences = $_['preferences'];
 $annotations = $_['annotations'];
 $title = htmlentities(basename($downloadLink));
 $revision = '0048';
-$version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+/* Get the app version for cache busting and the content security policy nonce depening on api availability */
+$revision = '0049';
+if (class_exists('\OCP\Server')) {
+    $appManager = \OCP\Server::get(\OCP\App\IAppManager::class);
+    $version = $appManager->getAppVersion('epubviewer') . '.' . $revision;
+
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+} else {
+    // legacy fallback (pre NC28)
+    $version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+    $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
+
+
 
 /* Mobile safari, the new IE6 */
 $idevice = (strstr($_SERVER['HTTP_USER_AGENT'], 'iPhone')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPad')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPod'));
 
-/* Get the content security policy nonce */
-$nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 ?>
 
 <html dir="ltr">

--- a/templates/epubviewer.php
+++ b/templates/epubviewer.php
@@ -1,4 +1,6 @@
 <?php
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+use OCP\Server;
 /** @var array $_ */
 /** @var OCP\IURLGenerator $urlGenerator */
 $urlGenerator = $_['urlGenerator'];
@@ -12,16 +14,23 @@ $defaults = $_['defaults'];
 $preferences = $_['preferences'];
 $annotations = $_['annotations'];
 $title = htmlentities(basename($downloadLink));
-$revision = '0072';
-$version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+/* Get the app version for cache busting and the content security policy nonce depening on api availability */
+$revision = '0073';
+if (class_exists('\OCP\Server')) {
+    $appManager = \OCP\Server::get(\OCP\App\IAppManager::class);
+    $version = $appManager->getAppVersion('epubviewer') . '.' . $revision;
+
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+} else {
+    // legacy fallback (pre NC28)
+    $version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+    $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
 
 /* Mobile safari, the new IE6 */
 $idevice = (strstr($_SERVER['HTTP_USER_AGENT'], 'iPhone')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPad')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPod'));
-
-/* Get the content security policy nonce */
-$nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 ?>
 
 <html dir="ltr">

--- a/templates/pdfreader.php
+++ b/templates/pdfreader.php
@@ -1,4 +1,6 @@
 <?php
+use OC\Security\CSP\ContentSecurityPolicyNonceManager;
+use OCP\Server;
 /** @var array $_ */
 /** @var OCP\IURLGenerator $urlGenerator */
 $urlGenerator = $_['urlGenerator'];
@@ -12,16 +14,24 @@ $defaults = $_['defaults'];
 $preferences = $_['preferences'];
 $annotations = $_['annotations'];
 $title = htmlentities(basename($downloadLink));
-$revision = '0134';
-$version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+/* Get the app version for cache busting and the content security policy nonce depening on api availability */
+$revision = '0135';
+if (class_exists('\OCP\Server')) {
+    $appManager = \OCP\Server::get(\OCP\App\IAppManager::class);
+    $version = $appManager->getAppVersion('epubviewer') . '.' . $revision;
+
+    $nonce = \OCP\Server::get(\OC\Security\CSP\ContentSecurityPolicyNonceManager::class)->getNonce();
+} else {
+    // legacy fallback (pre NC28)
+    $version = OC::$server->getAppManager()->getAppVersion('epubviewer') . '.' . $revision;
+    $nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
+}
 
 /* Mobile safari, the new IE6 */
 $idevice = (strstr($_SERVER['HTTP_USER_AGENT'], 'iPhone')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPad')
 	|| strstr($_SERVER['HTTP_USER_AGENT'], 'iPod'));
 
-/* Get the content security policy nonce */
-$nonce = \OC::$server->getContentSecurityPolicyNonceManager()->getNonce();
 ?>
 
 <html dir="ltr">


### PR DESCRIPTION
Did stumble over the version 34 incompatibility and - not really being an experienced php programmer and on top of that not knowing a lot about NC architecture - it took a few hours with this random word generator to get something that would be fixing this.
Basically my understanding is that OC:: is not supported anymore and that we need to get to the new API.
Luckily it seems only to affect
* version retrieval for cache busting and
* nonce generation
in the three template files.
As I do not know the effect on pre-34 versions and can't test it I kept the legacy code.

Thanks
Wolf